### PR TITLE
Change the indicator_sort_order values to non-numeric

### DIFF
--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '01-01-01'
 permalink: /1-1-1/
 sdg_goal: '1'
 title: Proportion of population below the international poverty line, by sex, age, employment status and geographical location (urban/rural)

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '01-02-01'
 permalink: /1-2-1/
 sdg_goal: '1'
 title: Proportion of population living below the national poverty line, by sex and age

--- a/meta/1-2-2.md
+++ b/meta/1-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.2.2
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '01-02-02'
 permalink: /1-2-2/
 sdg_goal: '1'
 title: Proportion of men, women and children of all ages living in poverty in all its dimensions according to national definitions

--- a/meta/1-3-1.md
+++ b/meta/1-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '01-03-01'
 permalink: /1-3-1/
 sdg_goal: '1'
 title: Proportion of population covered by social protection floors/systems, by sex, distinguishing children, unemployed persons, older persons, persons with disabilities, pregnant women, newborns, work-injury victims and the poor and the vulnerable

--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 1.4.1
 indicator_name: Proportion of population living in households with access to basic
   services
-indicator_sort_order: '0050'
+indicator_sort_order: '01-04-01'
 layout: indicator
 permalink: /1-4-1/
 published: true

--- a/meta/1-4-2.md
+++ b/meta/1-4-2.md
@@ -7,7 +7,7 @@ indicator: 1.4.2
 indicator_name: Proportion of total adult population with secure tenure rights to
   land, with legally recognized documentation and who perceive their rights to land
   as secure, by sex and by type of tenure
-indicator_sort_order: '0060'
+indicator_sort_order: '01-04-02'
 layout: indicator
 permalink: /1-4-2/
 published: true

--- a/meta/1-5-1.md
+++ b/meta/1-5-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 1.5.1
 indicator_name: Number of deaths, missing persons and directly affected persons attributed
   to disasters per 100,000 population (repeat of 1 and 13.1.1)
-indicator_sort_order: '0070'
+indicator_sort_order: '01-05-01'
 layout: indicator
 permalink: /1-5-1/
 published: true

--- a/meta/1-5-2.md
+++ b/meta/1-5-2.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 1.5.2
 indicator_name: Direct economic loss attributed to disasters in relation to global
   gross domestic product (GDP)
-indicator_sort_order: '0080'
+indicator_sort_order: '01-05-02'
 layout: indicator
 permalink: /1-5-2/
 published: true

--- a/meta/1-5-3.md
+++ b/meta/1-5-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.5.3
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '01-05-03'
 permalink: /1-5-3/
 sdg_goal: '1'
 title: Number of countries that adopt and implement national disaster risk reduction strategies in line with the Sendai Framework for Disaster Risk Reduction 2015-2030

--- a/meta/1-5-4.md
+++ b/meta/1-5-4.md
@@ -4,7 +4,7 @@ graph_type: line
 indicator: 1.5.4
 indicator_name: Proportion of local governments that adopt and implement local disaster
   risk reduction strategies in line with national disaster risk reduction strategies
-indicator_sort_order: '0100'
+indicator_sort_order: '01-05-04'
 layout: indicator
 permalink: /1-5-4/
 published: true

--- a/meta/1-a-1.md
+++ b/meta/1-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.a.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: '01-0a-01'
 permalink: /1-a-1/
 sdg_goal: '1'
 title: Proportion of domestically generated resources allocated by the government directly to poverty reduction programmes

--- a/meta/1-a-2.md
+++ b/meta/1-a-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.a.2
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: '01-0a-02'
 permalink: /1-a-2/
 sdg_goal: '1'
 title: Proportion of total government spending on essential services (education, health and social protection)

--- a/meta/1-a-3.md
+++ b/meta/1-a-3.md
@@ -4,7 +4,7 @@ graph_type: line
 indicator: 1.a.3
 indicator_name: Sum of total grants and non-debt-creating inflows directly allocated
   to poverty reduction programmes as a proportion of GDP
-indicator_sort_order: '0130'
+indicator_sort_order: '01-0a-03'
 layout: indicator
 permalink: /1-a-3/
 published: true

--- a/meta/1-b-1.md
+++ b/meta/1-b-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 1.b.1
 indicator_name: Proportion of government recurrent and capital spending to sectors
   that disproportionately benefit women, the poor and vulnerable groups
-indicator_sort_order: '0140'
+indicator_sort_order: '01-0b-01'
 layout: indicator
 permalink: /1-b-1/
 published: true

--- a/meta/10-1-1.md
+++ b/meta/10-1-1.md
@@ -18,5 +18,5 @@ title: Growth rates of household expenditure or income per capita among the bott
   40 per cent of the population and the total population
 un_custodian_agency: World Bank (WB)
 un_designated_tier: 2
-indicator_sort_order: '0010'
+indicator_sort_order: '10-01-01'
 ---

--- a/meta/10-2-1.md
+++ b/meta/10-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '10-02-01'
 permalink: /10-2-1/
 sdg_goal: '10'
 title: Proportion of people living below 50 per cent of median income, by sex, age and persons with disabilities

--- a/meta/10-3-1.md
+++ b/meta/10-3-1.md
@@ -7,7 +7,7 @@ indicator: 10.3.1
 indicator_name: Proportion of population reporting having personally felt discriminated
   against or harassed in the previous 12 months on the basis of a ground of discrimination
   prohibited under international human rights law
-indicator_sort_order: '0030'
+indicator_sort_order: '10-03-01'
 layout: indicator
 permalink: /10-3-1/
 published: true

--- a/meta/10-4-1.md
+++ b/meta/10-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.4.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '10-04-01'
 permalink: /10-4-1/
 sdg_goal: '10'
 title: Labour share of GDP, comprising wages and social protection transfers

--- a/meta/10-5-1.md
+++ b/meta/10-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.5.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '10-05-01'
 permalink: /10-5-1/
 sdg_goal: '10'
 title: Financial Soundness Indicators

--- a/meta/10-6-1.md
+++ b/meta/10-6-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 10.6.1
 indicator_name: Proportion of members and voting rights of developing countries in
   international organizations
-indicator_sort_order: '0060'
+indicator_sort_order: '10-06-01'
 layout: indicator
 permalink: /10-6-1/
 published: true

--- a/meta/10-7-1.md
+++ b/meta/10-7-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 10.7.1
 indicator_name: Recruitment cost borne by employee as a proportion of yearly income
   earned in country of destination
-indicator_sort_order: '0070'
+indicator_sort_order: '10-07-01'
 layout: indicator
 permalink: /10-7-1/
 published: true

--- a/meta/10-7-2.md
+++ b/meta/10-7-2.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 10.7.2
 indicator_name: Number of countries that have implemented well-managed migration policies
-indicator_sort_order: '0080'
+indicator_sort_order: '10-07-02'
 layout: indicator
 permalink: /10-7-2/
 published: true

--- a/meta/10-a-1.md
+++ b/meta/10-a-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 10.a.1
 indicator_name: Proportion of tariff lines applied to imports from least developed
   countries and developing countries with zero-tariff
-indicator_sort_order: '0090'
+indicator_sort_order: '10-0a-01'
 layout: indicator
 permalink: /10-a-1/
 published: true

--- a/meta/10-b-1.md
+++ b/meta/10-b-1.md
@@ -10,7 +10,7 @@ indicator_definition: Total resource flows for development, by recipient and don
 indicator_name: Total resource flows for development, by recipient and donor countries
   and type of flow (e.g. official development assistance, foreign direct investment
   and other flows)
-indicator_sort_order: '0100'
+indicator_sort_order: '10-0b-01'
 layout: indicator
 permalink: /10-b-1/
 published: true

--- a/meta/10-c-1.md
+++ b/meta/10-c-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 10.c.1
 indicator_name: Remittance costs as a proportion of the amount remitted
-indicator_sort_order: '0110'
+indicator_sort_order: '10-0c-01'
 layout: indicator
 permalink: /10-c-1/
 published: true

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '11-01-01'
 permalink: /11-1-1/
 sdg_goal: '11'
 title: Proportion of urban population living in slums, informal settlements or inadequate housing

--- a/meta/11-2-1.md
+++ b/meta/11-2-1.md
@@ -2,7 +2,7 @@
 indicator: 11.2.1
 
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '11-02-01'
 permalink: /11-2-1/
 sdg_goal: '11'
 title: Proportion of population that has convenient access to public transport, by sex, age and persons with disabilities

--- a/meta/11-3-1.md
+++ b/meta/11-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.3.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '11-03-01'
 permalink: /11-3-1/
 sdg_goal: '11'
 title: Ratio of land consumption rate to population growth rate

--- a/meta/11-3-2.md
+++ b/meta/11-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.3.2
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '11-03-02'
 permalink: /11-3-2/
 sdg_goal: '11'
 title: Proportion of cities with a direct participation structure of civil society in urban planning and management that operate regularly and democratically

--- a/meta/11-4-1.md
+++ b/meta/11-4-1.md
@@ -8,7 +8,7 @@ indicator_name: Total expenditure (public and private) per capita spent on the p
   (cultural, natural, mixed and World Heritage Centre designation), level of government
   (national, regional and local/municipal), type of expenditure (operating expenditure/investment)
   and type of private funding (donations in kind, private non-profit sector and sponsorship)
-indicator_sort_order: '0050'
+indicator_sort_order: '11-04-01'
 layout: indicator
 permalink: /11-4-1/
 published: true

--- a/meta/11-5-1.md
+++ b/meta/11-5-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 11.5.1
 indicator_name: Number of deaths, missing persons and directly affected persons attributed
   to disasters per 100,000 population (repeat of and 13.1.1)
-indicator_sort_order: '0060'
+indicator_sort_order: '11-05-01'
 layout: indicator
 permalink: /11-5-1/
 published: true

--- a/meta/11-5-2.md
+++ b/meta/11-5-2.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 11.5.2
 indicator_name: Direct economic loss in relation to global GDP, damage to critical
   infrastructure and number of disruptions to basic services, attributed to disasters
-indicator_sort_order: '0070'
+indicator_sort_order: '11-05-02'
 layout: indicator
 permalink: /11-5-2/
 published: true

--- a/meta/11-6-1.md
+++ b/meta/11-6-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 11.6.1
 indicator_name: Proportion of urban solid waste regularly collected and with adequate
   final discharge out of total urban solid waste generated, by cities
-indicator_sort_order: '0080'
+indicator_sort_order: '11-06-01'
 layout: indicator
 permalink: /11-6-1/
 published: true

--- a/meta/11-6-2.md
+++ b/meta/11-6-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.6.2
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '11-06-02'
 permalink: /11-6-2/
 sdg_goal: '11'
 title: Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10) in cities (population weighted)

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.7.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: '11-07-01'
 permalink: /11-7-1/
 sdg_goal: '11'
 title: Average share of the built-up area of cities that is open space for public use for all, by sex, age and persons with disabilities

--- a/meta/11-7-2.md
+++ b/meta/11-7-2.md
@@ -8,7 +8,7 @@ indicator_definition: Proportion of persons victim of physical or sexual harassm
   by sex, age, disability status and place of occurrence, in the previous 12 months
 indicator_name: Proportion of persons victim of physical or sexual harassment, by
   sex, age, disability status and place of occurrence, in the previous 12 months
-indicator_sort_order: '0110'
+indicator_sort_order: '11-07-02'
 layout: indicator
 permalink: /11-7-2/
 published: true

--- a/meta/11-a-1.md
+++ b/meta/11-a-1.md
@@ -6,7 +6,7 @@ indicator: 11.a.1
 indicator_name: Proportion of population living in cities that implement urban and
   regional development plans integrating population projections and resource needs,
   by size of city
-indicator_sort_order: '0120'
+indicator_sort_order: '11-0a-01'
 layout: indicator
 permalink: /11-a-1/
 published: true

--- a/meta/11-b-1.md
+++ b/meta/11-b-1.md
@@ -6,7 +6,7 @@ indicator: 11.b.1
 indicator_name: Number of countries that adopt and implement national disaster risk
   reduction strategies in line with the Sendai Framework for Disaster Risk Reduction
   2015-2030
-indicator_sort_order: '0130'
+indicator_sort_order: '11-0b-01'
 layout: indicator
 permalink: /11-b-1/
 published: true

--- a/meta/11-b-2.md
+++ b/meta/11-b-2.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 11.b.2
 indicator_name: Proportion of local governments that adopt and implement local disaster
   risk reduction strategies in line with national disaster risk reduction strategies
-indicator_sort_order: '0140'
+indicator_sort_order: '11-0b-02'
 layout: indicator
 permalink: /11-b-2/
 published: true

--- a/meta/11-c-1.md
+++ b/meta/11-c-1.md
@@ -10,7 +10,7 @@ indicator_definition: Proportion of financial support to the least developed cou
 indicator_name: Proportion of financial support to the least developed countries that
   is allocated to the construction and retrofitting of sustainable, resilient and
   resource-efficient buildings utilizing local materials
-indicator_sort_order: '0150'
+indicator_sort_order: '11-0c-01'
 layout: indicator
 permalink: /11-c-1/
 published: true

--- a/meta/12-1-1.md
+++ b/meta/12-1-1.md
@@ -6,7 +6,7 @@ indicator: 12.1.1
 indicator_name: Number of countries with sustainable consumption and production (SCP)
   national action plans or SCP mainstreamed as a priority or a target into national
   policies
-indicator_sort_order: '0010'
+indicator_sort_order: '12-01-01'
 layout: indicator
 permalink: /12-1-1/
 published: true

--- a/meta/12-2-1.md
+++ b/meta/12-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '12-02-01'
 permalink: /12-2-1/
 sdg_goal: '12'
 title: Material footprint, material footprint per capita, and material footprint per GDP

--- a/meta/12-2-2.md
+++ b/meta/12-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.2.2
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '12-02-02'
 permalink: /12-2-2/
 sdg_goal: '12'
 title: Domestic material consumption, domestic material consumption per capita, and domestic material consumption per GDP

--- a/meta/12-3-1.md
+++ b/meta/12-3-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 12.3.1
 indicator_name: Global food loss index
-indicator_sort_order: '0040'
+indicator_sort_order: '12-03-01'
 layout: indicator
 permalink: /12-3-1/
 published: true

--- a/meta/12-4-1.md
+++ b/meta/12-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.4.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '12-04-01'
 permalink: /12-4-1/
 sdg_goal: '12'
 title: Number of parties to international multilateral environmental agreements on hazardous waste, and other chemicals that meet their commitments and obligations in transmitting information as required by each relevant agreement

--- a/meta/12-4-2.md
+++ b/meta/12-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.4.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: '12-04-02'
 permalink: /12-4-2/
 sdg_goal: '12'
 title: Hazardous waste generated per capita and proportion of hazardous waste treated, by type of treatment

--- a/meta/12-5-1.md
+++ b/meta/12-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '12-05-01'
 permalink: /12-5-1/
 sdg_goal: '12'
 title: National recycling rate, tons of material recycled

--- a/meta/12-6-1.md
+++ b/meta/12-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.6.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: '12-06-01'
 permalink: /12-6-1/
 sdg_goal: '12'
 title: Number of companies publishing sustainability reports

--- a/meta/12-7-1.md
+++ b/meta/12-7-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 12.7.1
 indicator_name: Number of countries implementing sustainable public procurement policies
   and action plans
-indicator_sort_order: '0090'
+indicator_sort_order: '12-07-01'
 layout: indicator
 permalink: /12-7-1/
 published: true

--- a/meta/12-8-1.md
+++ b/meta/12-8-1.md
@@ -7,7 +7,7 @@ indicator_name: "Extent to which (i) global citizenship education and (ii) educa
   \ for sustainable development (including climate change education) are mainstreamed\
   \ in (a) national education policies; (b)\_curricula; (c) teacher education; and\
   \ (d) student assessment"
-indicator_sort_order: '0100'
+indicator_sort_order: '12-08-01'
 layout: indicator
 permalink: /12-8-1/
 published: true

--- a/meta/12-a-1.md
+++ b/meta/12-a-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 12.a.1
 indicator_name: Amount of support to developing countries on research and development
   for sustainable consumption and production and environmentally sound technologies
-indicator_sort_order: '0110'
+indicator_sort_order: '12-0a-01'
 layout: indicator
 permalink: /12-a-1/
 published: true

--- a/meta/12-b-1.md
+++ b/meta/12-b-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 12.b.1
 indicator_name: Number of sustainable tourism strategies or policies and implemented
   action plans with agreed monitoring and evaluation tools
-indicator_sort_order: '0120'
+indicator_sort_order: '12-0b-01'
 layout: indicator
 permalink: /12-b-1/
 published: true

--- a/meta/12-c-1.md
+++ b/meta/12-c-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 12.c.1
 indicator_name: Amount of fossil-fuel subsidies per unit of GDP (production and consumption)
   and as a proportion of total national expenditure on fossil fuels
-indicator_sort_order: '0130'
+indicator_sort_order: '12-0c-01'
 layout: indicator
 permalink: /12-c-1/
 published: true

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 13.1.1
 indicator_name: Number of deaths, missing persons and directly affected persons attributed
   to disasters per 100,000 population
-indicator_sort_order: '0010'
+indicator_sort_order: '13-01-01'
 layout: indicator
 permalink: /13-1-1/
 published: true

--- a/meta/13-1-2.md
+++ b/meta/13-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 13.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '13-01-02'
 permalink: /13-1-2/
 sdg_goal: '13'
 title: Number of countries that adopt and implement national disaster risk reduction strategies in line with the Sendai Framework for Disaster Risk Reduction 2015-2030

--- a/meta/13-1-3.md
+++ b/meta/13-1-3.md
@@ -4,7 +4,7 @@ graph_type: line
 indicator: 13.1.3
 indicator_name: Proportion of local governments that adopt and implement local disaster
   risk reduction strategies in line with national disaster risk reduction strategies
-indicator_sort_order: '0030'
+indicator_sort_order: '13-01-03'
 layout: indicator
 permalink: /13-1-3/
 published: true

--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -9,7 +9,7 @@ indicator_name: Number of countries that have communicated the establishment or 
   gas emissions development in a manner that does not threaten food production (including
   a national adaptation plan, nationally determined contribution, national communication,
   biennial update report or other)
-indicator_sort_order: '0040'
+indicator_sort_order: '13-02-01'
 layout: indicator
 permalink: /13-2-1/
 published: true

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 13.3.1
 indicator_name: Number of countries that have integrated mitigation, adaptation, impact
   reduction and early warning into primary, secondary and tertiary curricula
-indicator_sort_order: '0050'
+indicator_sort_order: '13-03-01'
 layout: indicator
 permalink: /13-3-1/
 published: true

--- a/meta/13-3-2.md
+++ b/meta/13-3-2.md
@@ -6,7 +6,7 @@ indicator: 13.3.2
 indicator_name: Number of countries that have communicated the strengthening of institutional,
   systemic and individual capacity-building to implement adaptation, mitigation and
   technology transfer, and development actions
-indicator_sort_order: '0060'
+indicator_sort_order: '13-03-02'
 layout: indicator
 permalink: /13-3-2/
 published: true

--- a/meta/13-a-1.md
+++ b/meta/13-a-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 13.a.1
 indicator_name: "Mobilized amount of United States dollars per year between 2020 and\
   \ 2025 accountable towards the $100\_billion commitment"
-indicator_sort_order: '0070'
+indicator_sort_order: '13-0a-01'
 layout: indicator
 permalink: /13-a-1/
 published: true

--- a/meta/13-b-1.md
+++ b/meta/13-b-1.md
@@ -8,7 +8,7 @@ indicator_name: Number of least developed countries and small island developing 
   technology and capacity-building, for mechanisms for raising capacities for effective
   climate change-related planning and management, including focusing on women, youth
   and local and marginalized communities
-indicator_sort_order: '0080'
+indicator_sort_order: '13-0b-01'
 layout: indicator
 permalink: /13-b-1/
 published: true

--- a/meta/14-1-1.md
+++ b/meta/14-1-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 14.1.1
 indicator_name: Index of coastal eutrophication and floating plastic debris density
-indicator_sort_order: '0010'
+indicator_sort_order: '14-01-01'
 layout: indicator
 permalink: /14-1-1/
 published: true

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 14.2.1
 indicator_name: Proportion of national exclusive economic zones managed using ecosystem-based
   approaches
-indicator_sort_order: '0020'
+indicator_sort_order: '14-02-01'
 layout: indicator
 permalink: /14-2-1/
 published: true

--- a/meta/14-3-1.md
+++ b/meta/14-3-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 14.3.1
 indicator_name: Average marine acidity (pH) measured at agreed suite of representative
   sampling stations
-indicator_sort_order: '0030'
+indicator_sort_order: '14-03-01'
 layout: indicator
 permalink: /14-3-1/
 published: true

--- a/meta/14-4-1.md
+++ b/meta/14-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 14.4.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '14-04-01'
 permalink: /14-4-1/
 sdg_goal: '14'
 title: Proportion of fish stocks within biologically sustainable levels

--- a/meta/14-5-1.md
+++ b/meta/14-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 14.5.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '14-05-01'
 permalink: /14-5-1/
 sdg_goal: '14'
 title: Coverage of protected areas in relation to marine areas

--- a/meta/14-6-1.md
+++ b/meta/14-6-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 14.6.1
 indicator_name: Progress by countries in the degree of implementation of international
   instruments aiming to combat illegal, unreported and unregulated fishing
-indicator_sort_order: '0060'
+indicator_sort_order: '14-06-01'
 layout: indicator
 permalink: /14-6-1/
 published: true

--- a/meta/14-7-1.md
+++ b/meta/14-7-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 14.7.1
 indicator_name: Sustainable fisheries as a proportion of GDP in small island developing
   States, least developed countries and all countries
-indicator_sort_order: '0070'
+indicator_sort_order: '14-07-01'
 layout: indicator
 permalink: /14-7-1/
 published: true

--- a/meta/14-a-1.md
+++ b/meta/14-a-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 14.a.1
 indicator_name: Proportion of total research budget allocated to research in the field
   of marine technology
-indicator_sort_order: '0080'
+indicator_sort_order: '14-0a-01'
 layout: indicator
 permalink: /14-a-1/
 published: true

--- a/meta/14-b-1.md
+++ b/meta/14-b-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 14.b.1
 indicator_name: Progress by countries in the degree of application of a legal/regulatory/policy/institutional
   framework which recognizes and protects access rights for small-scale fisheries
-indicator_sort_order: '0090'
+indicator_sort_order: '14-0b-01'
 layout: indicator
 permalink: /14-b-1/
 published: true

--- a/meta/14-c-1.md
+++ b/meta/14-c-1.md
@@ -8,7 +8,7 @@ indicator_name: Number of countries making progress in ratifying, accepting and 
   implement international law, as reflected in the United Nation Convention on the
   Law of the Sea, for the conservation and sustainable use of the oceans and their
   resources
-indicator_sort_order: '0100'
+indicator_sort_order: '14-0c-01'
 layout: indicator
 permalink: /14-c-1/
 published: true

--- a/meta/15-1-1.md
+++ b/meta/15-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '15-01-01'
 permalink: /15-1-1/
 sdg_goal: '15'
 title: Forest area as a proportion of total land area

--- a/meta/15-1-2.md
+++ b/meta/15-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '15-01-02'
 permalink: /15-1-2/
 sdg_goal: '15'
 title: Proportion of important sites for terrestrial and freshwater biodiversity that are covered by protected areas, by ecosystem type

--- a/meta/15-2-1.md
+++ b/meta/15-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '15-02-01'
 permalink: /15-2-1/
 sdg_goal: '15'
 title: Progress towards sustainable forest management

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 15.3.1
 indicator_name: Proportion of land that is degraded over total land area
-indicator_sort_order: '0040'
+indicator_sort_order: '15-03-01'
 layout: indicator
 permalink: /15-3-1/
 published: true

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 15.4.1
 indicator_name: Coverage by protected areas of important sites for mountain biodiversity
-indicator_sort_order: '0050'
+indicator_sort_order: '15-04-01'
 layout: indicator
 permalink: /15-4-1/
 published: true

--- a/meta/15-4-2.md
+++ b/meta/15-4-2.md
@@ -5,7 +5,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 
 graph_type: line
 indicator: 15.4.2
 indicator_name: Mountain Green Cover Index
-indicator_sort_order: '0060'
+indicator_sort_order: '15-04-02'
 layout: indicator
 permalink: /15-4-2/
 published: true

--- a/meta/15-5-1.md
+++ b/meta/15-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '15-05-01'
 permalink: /15-5-1/
 sdg_goal: '15'
 title: Red List Index

--- a/meta/15-6-1.md
+++ b/meta/15-6-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 15.6.1
 indicator_name: Number of countries that have adopted legislative, administrative
   and policy frameworks to ensure fair and equitable sharing of benefits
-indicator_sort_order: '0080'
+indicator_sort_order: '15-06-01'
 layout: indicator
 permalink: /15-6-1/
 published: true

--- a/meta/15-7-1.md
+++ b/meta/15-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.7.1
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '15-07-01'
 permalink: /15-7-1/
 sdg_goal: '15'
 title: Proportion of traded wildlife that was poached or illicitly trafficked

--- a/meta/15-8-1.md
+++ b/meta/15-8-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 15.8.1
 indicator_name: Proportion of countries adopting relevant national legislation and
   adequately resourcing the prevention or control of invasive alien species
-indicator_sort_order: '0100'
+indicator_sort_order: '15-08-01'
 layout: indicator
 permalink: /15-8-1/
 published: true

--- a/meta/15-9-1.md
+++ b/meta/15-9-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 15.9.1
 indicator_name: Progress towards national targets established in accordance with Aichi
   Biodiversity Target 2 of the Strategic Plan for Biodiversity 2011-2020
-indicator_sort_order: '0110'
+indicator_sort_order: '15-09-01'
 layout: indicator
 permalink: /15-9-1/
 published: true

--- a/meta/15-a-1.md
+++ b/meta/15-a-1.md
@@ -8,7 +8,7 @@ indicator_definition: Total ODA flows to developing countries quantify the publi
   effort that donors provide to developing countries for biodiversity.
 indicator_name: Official development assistance and public expenditure on conservation
   and sustainable use of biodiversity and ecosystems
-indicator_sort_order: '0120'
+indicator_sort_order: '15-0a-01'
 layout: indicator
 permalink: /15-a-1/
 published: true

--- a/meta/15-b-1.md
+++ b/meta/15-b-1.md
@@ -8,7 +8,7 @@ indicator_definition: Total ODA flows to developing countries quantify the publi
   effort that donors provide to developing countries for biodiversity.
 indicator_name: Official development assistance and public expenditure on conservation
   and sustainable use of biodiversity and ecosystems
-indicator_sort_order: '0130'
+indicator_sort_order: '15-0b-01'
 layout: indicator
 permalink: /15-b-1/
 published: true

--- a/meta/15-c-1.md
+++ b/meta/15-c-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 
 graph_type: line
 indicator: 15.c.1
 indicator_name: Proportion of traded wildlife that was poached or illicitly trafficked
-indicator_sort_order: '0140'
+indicator_sort_order: '15-0c-01'
 layout: indicator
 permalink: /15-c-1/
 published: true

--- a/meta/16-1-1.md
+++ b/meta/16-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '16-01-01'
 permalink: /16-1-1/
 sdg_goal: '16'
 title: Number of victims of intentional homicide per 100,000 population, by sex and age

--- a/meta/16-1-2.md
+++ b/meta/16-1-2.md
@@ -5,7 +5,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 
 graph_type: line
 indicator: 16.1.2
 indicator_name: Conflict-related deaths per 100,000 population, by sex, age and cause
-indicator_sort_order: '0020'
+indicator_sort_order: '16-01-02'
 layout: indicator
 permalink: /16-1-2/
 published: true

--- a/meta/16-1-3.md
+++ b/meta/16-1-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.1.3
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '16-01-03'
 permalink: /16-1-3/
 sdg_goal: '16'
 title: Proportion of population subjected to physical, psychological or sexual violence in the previous 12 months

--- a/meta/16-1-4.md
+++ b/meta/16-1-4.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.1.4
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '16-01-04'
 permalink: /16-1-4/
 sdg_goal: '16'
 title: Proportion of population that feel safe walking alone around the area they live

--- a/meta/16-10-1.md
+++ b/meta/16-10-1.md
@@ -6,7 +6,7 @@ indicator: 16.10.1
 indicator_name: Number of verified cases of killing, kidnapping, enforced disappearance,
   arbitrary detention and torture of journalists, associated media personnel, trade
   unionists and human rights advocates in the previous 12 months
-indicator_sort_order: '0200'
+indicator_sort_order: '16-10-01'
 layout: indicator
 permalink: /16-10-1/
 published: true

--- a/meta/16-10-2.md
+++ b/meta/16-10-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.10.2
 layout: indicator
-indicator_sort_order: '0210'
+indicator_sort_order: '16-10-02'
 permalink: /16-10-2/
 sdg_goal: '16'
 title: Number of countries that adopt and implement constitutional, statutory and/or policy guarantees for public access to information

--- a/meta/16-2-1.md
+++ b/meta/16-2-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 16.2.1
 indicator_name: Proportion of children aged 1-17 years who experienced any physical
   punishment and/or psychological aggression by caregivers in the past month
-indicator_sort_order: '0050'
+indicator_sort_order: '16-02-01'
 layout: indicator
 permalink: /16-2-1/
 published: true

--- a/meta/16-2-2.md
+++ b/meta/16-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.2.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: '16-02-02'
 permalink: /16-2-2/
 sdg_goal: '16'
 title: Number of victims of human trafficking per 100,000 population, by sex, age and form of exploitation

--- a/meta/16-2-3.md
+++ b/meta/16-2-3.md
@@ -11,7 +11,7 @@ indicator_definition: This indicator provides the proportion of young women and 
   women and men aged 18-24 years, respectively, in the population
 indicator_name: Proportion of young women and men aged 18-29 years who experienced
   sexual violence by age 18
-indicator_sort_order: '0070'
+indicator_sort_order: '16-02-03'
 layout: indicator
 permalink: /16-2-3/
 published: true

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -6,7 +6,7 @@ indicator: 16.3.1
 indicator_name: Proportion of victims of violence in the previous 12 months who reported
   their victimization to competent authorities or other officially recognized conflict
   resolution mechanisms
-indicator_sort_order: '0080'
+indicator_sort_order: '16-03-01'
 layout: indicator
 permalink: /16-3-1/
 published: true

--- a/meta/16-3-2.md
+++ b/meta/16-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.3.2
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '16-03-02'
 permalink: /16-3-2/
 sdg_goal: '16'
 title: Unsentenced detainees as a proportion of overall prison population

--- a/meta/16-4-1.md
+++ b/meta/16-4-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 16.4.1
 indicator_name: Total value of inward and outward illicit financial flows (in current
   United States dollars)
-indicator_sort_order: '0100'
+indicator_sort_order: '16-04-01'
 layout: indicator
 permalink: /16-4-1/
 published: true

--- a/meta/16-4-2.md
+++ b/meta/16-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.4.2
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: '16-04-02'
 permalink: /16-4-2/
 sdg_goal: '16'
 title: Proportion of seized, found or surrendered arms whose illicit origin or context has been traced or established by a competent authority in line with international instruments

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.5.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: '16-05-01'
 permalink: /16-5-1/
 sdg_goal: '16'
 title: Proportion of persons who had at least one contact with a public official and who paid a bribe to a public official, or were asked for a bribe by those public officials, during the previous 12 months

--- a/meta/16-5-2.md
+++ b/meta/16-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.5.2
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: '16-05-02'
 permalink: /16-5-2/
 sdg_goal: '16'
 title: Proportion of businesses that had at least one contact with a public official and that paid a bribe to a public official, or were asked for a bribe by those public officials during the previous 12 months

--- a/meta/16-6-1.md
+++ b/meta/16-6-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 16.6.1
 indicator_name: "Primary government expenditures as a proportion of original approved\
   \ budget, by sector (or\_by budget codes or similar)"
-indicator_sort_order: '0140'
+indicator_sort_order: '16-06-01'
 layout: indicator
 permalink: /16-6-1/
 published: true

--- a/meta/16-6-2.md
+++ b/meta/16-6-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.6.2
 layout: indicator
-indicator_sort_order: '0150'
+indicator_sort_order: '16-06-02'
 permalink: /16-6-2/
 sdg_goal: '16'
 title: Proportion of population satisfied with their last experience of public services

--- a/meta/16-7-1.md
+++ b/meta/16-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.7.1
 layout: indicator
-indicator_sort_order: '0160'
+indicator_sort_order: '16-07-01'
 permalink: /16-7-1/
 sdg_goal: '16'
 title: Proportions of positions (by sex, age, persons with disabilities and population groups) in public institutions (national and local legislatures, public service, and judiciary) compared to national distributions

--- a/meta/16-7-2.md
+++ b/meta/16-7-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.7.2
 layout: indicator
-indicator_sort_order: '0170'
+indicator_sort_order: '16-07-02'
 permalink: /16-7-2/
 sdg_goal: '16'
 title: Proportion of population who believe decision-making is inclusive and responsive, by sex, age, disability and population group

--- a/meta/16-8-1.md
+++ b/meta/16-8-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 16.8.1
 indicator_name: Proportion of members and voting rights of developing countries in
   international organizations
-indicator_sort_order: '0180'
+indicator_sort_order: '16-08-01'
 layout: indicator
 permalink: /16-8-1/
 published: true

--- a/meta/16-9-1.md
+++ b/meta/16-9-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.9.1
 layout: indicator
-indicator_sort_order: '0190'
+indicator_sort_order: '16-09-01'
 permalink: /16-9-1/
 sdg_goal: '16'
 title: Proportion of children under 5 years of age whose births have been registered with a civil authority, by age

--- a/meta/16-a-1.md
+++ b/meta/16-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.a.1
 layout: indicator
-indicator_sort_order: '0220'
+indicator_sort_order: '16-0a-01'
 permalink: /16-a-1/
 sdg_goal: '16'
 title: Existence of independent national human rights institutions in compliance with the Paris Principles

--- a/meta/16-b-1.md
+++ b/meta/16-b-1.md
@@ -7,7 +7,7 @@ indicator: 16.b.1
 indicator_name: Proportion of population reporting having personally felt discriminated
   against or harassed in the previous 12 months on the basis of a ground of discrimination
   prohibited under international human rights law
-indicator_sort_order: '0230'
+indicator_sort_order: '16-0b-01'
 layout: indicator
 permalink: /16-b-1/
 published: true

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -6,7 +6,7 @@ permalink: /17-1-1/
 sdg_goal: '17'
 title: Total government revenue as a proportion of GDP, by source
 indicator_name: Total government revenue as a proportion of GDP, by source
-
+indicator_sort_order: '17-01-01'
 target_id: '17.1'
 target: Strengthen domestic resource mobilization, including through international support to developing countries, to improve domestic capacity for tax and other revenue collection
 

--- a/meta/17-1-2.md
+++ b/meta/17-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '17-01-02'
 permalink: /17-1-2/
 sdg_goal: '17'
 title: Proportion of domestic budget funded by domestic taxes

--- a/meta/17-10-1.md
+++ b/meta/17-10-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 17.10.1
 indicator_name: Worldwide weighted tariff-average
-indicator_sort_order: '0130'
+indicator_sort_order: '17-10-01'
 layout: indicator
 permalink: /17-10-1/
 published: true

--- a/meta/17-11-1.md
+++ b/meta/17-11-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.11.1
 indicator_name: "Developing countries\u2019 and least developed countries\u2019 share\
   \ of global exports"
-indicator_sort_order: '0140'
+indicator_sort_order: '17-11-01'
 layout: indicator
 permalink: /17-11-1/
 published: true

--- a/meta/17-12-1.md
+++ b/meta/17-12-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.12.1
 indicator_name: Average tariffs faced by developing countries, least developed countries
   and small island developing States
-indicator_sort_order: '0150'
+indicator_sort_order: '17-12-01'
 layout: indicator
 permalink: /17-12-1/
 published: true

--- a/meta/17-13-1.md
+++ b/meta/17-13-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.13.1
 layout: indicator
-indicator_sort_order: '0160'
+indicator_sort_order: '17-13-01'
 permalink: /17-13-1/
 sdg_goal: '17'
 title: Macroeconomic Dashboard

--- a/meta/17-14-1.md
+++ b/meta/17-14-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.14.1
 indicator_name: Number of countries with mechanisms in place to enhance policy coherence
   of sustainable development
-indicator_sort_order: '0170'
+indicator_sort_order: '17-14-01'
 layout: indicator
 permalink: /17-14-1/
 published: true

--- a/meta/17-15-1.md
+++ b/meta/17-15-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.15.1
 indicator_name: Extent of use of country-owned results frameworks and planning tools
   by providers of development cooperation
-indicator_sort_order: '0180'
+indicator_sort_order: '17-15-01'
 layout: indicator
 permalink: /17-15-1/
 published: true

--- a/meta/17-16-1.md
+++ b/meta/17-16-1.md
@@ -6,7 +6,7 @@ indicator: 17.16.1
 indicator_name: Number of countries reporting progress in multi-stakeholder development
   effectiveness monitoring frameworks that support the achievement of the sustainable
   development goals
-indicator_sort_order: '0190'
+indicator_sort_order: '17-16-01'
 layout: indicator
 permalink: /17-16-1/
 published: true

--- a/meta/17-17-1.md
+++ b/meta/17-17-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.17.1
 indicator_name: Amount of United States dollars committed to public-private and civil
   society partnerships
-indicator_sort_order: '0200'
+indicator_sort_order: '17-17-01'
 layout: indicator
 permalink: /17-17-1/
 published: true

--- a/meta/17-18-1.md
+++ b/meta/17-18-1.md
@@ -6,7 +6,7 @@ indicator: 17.18.1
 indicator_name: Proportion of sustainable development indicators produced at the national
   level with full disaggregation when relevant to the target, in accordance with the
   Fundamental Principles of Official Statistics
-indicator_sort_order: '0210'
+indicator_sort_order: '17-18-01'
 layout: indicator
 permalink: /17-18-1/
 published: true

--- a/meta/17-18-2.md
+++ b/meta/17-18-2.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.18.2
 indicator_name: Number of countries that have national statistical legislation that
   complies with the Fundamental Principles of Official Statistics
-indicator_sort_order: '0220'
+indicator_sort_order: '17-18-02'
 layout: indicator
 permalink: /17-18-2/
 published: true

--- a/meta/17-18-3.md
+++ b/meta/17-18-3.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.18.3
 indicator_name: Number of countries with a national statistical plan that is fully
   funded and under implementation, by source of funding
-indicator_sort_order: '0230'
+indicator_sort_order: '17-18-03'
 layout: indicator
 permalink: /17-18-3/
 published: true

--- a/meta/17-19-1.md
+++ b/meta/17-19-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.19.1
 layout: indicator
-indicator_sort_order: '0240'
+indicator_sort_order: '17-19-01'
 permalink: /17-19-1/
 sdg_goal: '17'
 title: Dollar value of all resources made available to strengthen statistical capacity in developing countries

--- a/meta/17-19-2.md
+++ b/meta/17-19-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.19.2
 layout: indicator
-indicator_sort_order: '0250'
+indicator_sort_order: '17-19-02'
 permalink: /17-19-2/
 sdg_goal: '17'
 title: Proportion of countries that (a) have conducted at least one population and housing census in the last 10 years; and (b) have achieved 100 per cent birth registration and 80 per cent death registration

--- a/meta/17-2-1.md
+++ b/meta/17-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '17-02-01'
 permalink: /17-2-1/
 sdg_goal: '17'
 title: "Net official development assistance, total and to least developed countries, as a proportion of the Organization for Economic Cooperation and Development (OECD) Development Assistance Committee donors\u2019 gross national income (GNI)"

--- a/meta/17-3-1.md
+++ b/meta/17-3-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.3.1
 indicator_name: Foreign direct investments (FDI), official development assistance
   and South-South Cooperation as a proportion of total domestic budget
-indicator_sort_order: '0040'
+indicator_sort_order: '17-03-01'
 layout: indicator
 permalink: /17-3-1/
 published: true

--- a/meta/17-3-2.md
+++ b/meta/17-3-2.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.3.2
 indicator_name: Volume of remittances (in United States dollars) as a proportion of
   total GDP
-indicator_sort_order: '0050'
+indicator_sort_order: '17-03-02'
 layout: indicator
 permalink: /17-3-2/
 published: true

--- a/meta/17-4-1.md
+++ b/meta/17-4-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 17.4.1
 indicator_name: Debt service as a proportion of exports of goods and services
-indicator_sort_order: '0060'
+indicator_sort_order: '17-04-01'
 layout: indicator
 permalink: /17-4-1/
 published: true

--- a/meta/17-5-1.md
+++ b/meta/17-5-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.5.1
 indicator_name: Number of countries that adopt and implement investment promotion
   regimes for least developed countries
-indicator_sort_order: '0070'
+indicator_sort_order: '17-05-01'
 layout: indicator
 permalink: /17-5-1/
 published: true

--- a/meta/17-6-1.md
+++ b/meta/17-6-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 17.6.1
 indicator_name: Number of science and/or technology cooperation agreements and programmes
   between countries, by type of cooperation
-indicator_sort_order: '0080'
+indicator_sort_order: '17-06-01'
 layout: indicator
 permalink: /17-6-1/
 published: true

--- a/meta/17-6-2.md
+++ b/meta/17-6-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.6.2
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '17-06-02'
 permalink: /17-6-2/
 sdg_goal: '17'
 title: Fixed Internet broadband subscriptions per 100 inhabitants, by speed

--- a/meta/17-7-1.md
+++ b/meta/17-7-1.md
@@ -6,7 +6,7 @@ indicator: 17.7.1
 indicator_name: Total amount of approved funding for developing countries to promote
   the development, transfer, dissemination and diffusion of environmentally sound
   technologies
-indicator_sort_order: '0100'
+indicator_sort_order: '17-07-01'
 layout: indicator
 permalink: /17-7-1/
 published: true

--- a/meta/17-8-1.md
+++ b/meta/17-8-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.8.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: '17-08-01'
 permalink: /17-8-1/
 sdg_goal: '17'
 title: Proportion of individuals using the Internet

--- a/meta/17-9-1.md
+++ b/meta/17-9-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.9.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: '17-09-01'
 permalink: /17-9-1/
 sdg_goal: '17'
 title: Dollar value of financial and technical assistance (including through North-South, South-South and triangular cooperation) committed to developing countries

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '02-01-01'
 permalink: /2-1-1/
 sdg_goal: '2'
 title: Prevalence of undernourishment

--- a/meta/2-1-2.md
+++ b/meta/2-1-2.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 2.1.2
 indicator_name: Prevalence of moderate or severe food insecurity in the population,
   based on the Food Insecurity Experience Scale (FIES)
-indicator_sort_order: '0020'
+indicator_sort_order: '02-01-02'
 layout: indicator
 permalink: /2-1-2/
 published: true

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '02-02-01'
 permalink: /2-2-1/
 sdg_goal: '2'
 title: Prevalence of stunting (height for age <-2 standard deviation from the median of the World Health Organization (WHO) Child Growth Standards) among children under 5 years of age

--- a/meta/2-2-2.md
+++ b/meta/2-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.2.2
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '02-02-02'
 permalink: /2-2-2/
 sdg_goal: '2'
 title: Prevalence of malnutrition (weight for height >+2 or <-2 standard deviation from the median of the WHO Child Growth Standards) among children under 5 years of age, by type (wasting and overweight)

--- a/meta/2-3-1.md
+++ b/meta/2-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.3.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '02-03-01'
 permalink: /2-3-1/
 sdg_goal: '2'
 title: Volume of production per labour unit by classes of farming/pastoral/forestry enterprise size

--- a/meta/2-3-2.md
+++ b/meta/2-3-2.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 2.3.2
 indicator_name: Average income of small-scale food producers, by sex and indigenous
   status
-indicator_sort_order: '0060'
+indicator_sort_order: '02-03-02'
 layout: indicator
 permalink: /2-3-2/
 published: true

--- a/meta/2-4-1.md
+++ b/meta/2-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.4.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '02-04-01'
 permalink: /2-4-1/
 sdg_goal: '2'
 title: Proportion of agricultural area under productive and sustainable agriculture

--- a/meta/2-5-1.md
+++ b/meta/2-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.5.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: '02-05-01'
 permalink: /2-5-1/
 sdg_goal: '2'
 title: Number of plant and animal genetic resources for food and agriculture secured in either medium or long-term conservation facilities

--- a/meta/2-5-2.md
+++ b/meta/2-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.5.2
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '02-05-02'
 permalink: /2-5-2/
 sdg_goal: '2'
 title: Proportion of local breeds classified as being at risk, not-at-risk or at unknown level of risk of extinction

--- a/meta/2-a-1.md
+++ b/meta/2-a-1.md
@@ -11,7 +11,7 @@ indicator_definition: "An Agriculture Orientation Index (AOI) greater than 1 ref
   \ to 1 reflects neutrality in a government\u2019s orientation to the agriculture\
   \ sector."
 indicator_name: The agriculture orientation index for government expenditures
-indicator_sort_order: '0100'
+indicator_sort_order: '02-0a-01'
 layout: indicator
 permalink: /2-a-1/
 published: true

--- a/meta/2-a-2.md
+++ b/meta/2-a-2.md
@@ -8,7 +8,7 @@ indicator_definition: Gross disbursements of total ODA and other official flows 
   all donors to the agriculture sector.
 indicator_name: Total official flows (official development assistance plus other official
   flows) to the agriculture sector
-indicator_sort_order: '0110'
+indicator_sort_order: '02-0a-02'
 layout: indicator
 permalink: /2-a-2/
 published: true

--- a/meta/2-b-1.md
+++ b/meta/2-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.b.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: '02-0b-01'
 permalink: /2-b-1/
 sdg_goal: '2'
 title: Agricultural export subsidies

--- a/meta/2-c-1.md
+++ b/meta/2-c-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 2.c.1
 indicator_name: Indicator of food price anomalies
-indicator_sort_order: '0130'
+indicator_sort_order: '02-0c-01'
 layout: indicator
 permalink: /2-c-1/
 published: true

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '03-01-01'
 permalink: /3-1-1/
 sdg_goal: '3'
 title: Maternal mortality ratio

--- a/meta/3-1-2.md
+++ b/meta/3-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '03-01-02'
 permalink: /3-1-2/
 sdg_goal: '3'
 title: Proportion of births attended by skilled health personnel

--- a/meta/3-2-1.md
+++ b/meta/3-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '03-02-01'
 permalink: /3-2-1/
 sdg_goal: '3'
 title: Under-five mortality rate

--- a/meta/3-2-2.md
+++ b/meta/3-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.2.2
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '03-02-02'
 permalink: /3-2-2/
 sdg_goal: '3'
 title: Neonatal mortality rate

--- a/meta/3-3-1.md
+++ b/meta/3-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '03-03-01'
 permalink: /3-3-1/
 sdg_goal: '3'
 title: Number of new HIV infections per 1,000 uninfected population, by sex, age and key populations

--- a/meta/3-3-2.md
+++ b/meta/3-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: '03-03-02'
 permalink: /3-3-2/
 sdg_goal: '3'
 title: Tuberculosis incidence per 100,000 population

--- a/meta/3-3-3.md
+++ b/meta/3-3-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.3
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '03-03-03'
 permalink: /3-3-3/
 sdg_goal: '3'
 title: Malaria incidence per 1,000 population

--- a/meta/3-3-4.md
+++ b/meta/3-3-4.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.4
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: '03-03-04'
 permalink: /3-3-4/
 sdg_goal: '3'
 title: Hepatitis B incidence per 100,000 population

--- a/meta/3-3-5.md
+++ b/meta/3-3-5.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 3.3.5
 indicator_name: Number of people requiring interventions against neglected tropical
   diseases
-indicator_sort_order: '0090'
+indicator_sort_order: '03-03-05'
 layout: indicator
 permalink: /3-3-5/
 published: true

--- a/meta/3-4-1.md
+++ b/meta/3-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.4.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: '03-04-01'
 permalink: /3-4-1/
 sdg_goal: '3'
 title: Mortality rate attributed to cardiovascular disease, cancer, diabetes or chronic respiratory disease

--- a/meta/3-4-2.md
+++ b/meta/3-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.4.2
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: '03-04-02'
 permalink: /3-4-2/
 sdg_goal: '3'
 title: Suicide mortality rate

--- a/meta/3-5-1.md
+++ b/meta/3-5-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 3.5.1
 indicator_name: Coverage of treatment interventions (pharmacological, psychosocial
   and rehabilitation and aftercare services) for substance use disorders
-indicator_sort_order: '0120'
+indicator_sort_order: '03-05-01'
 layout: indicator
 permalink: /3-5-1/
 published: true

--- a/meta/3-5-2.md
+++ b/meta/3-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.5.2
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: '03-05-02'
 permalink: /3-5-2/
 sdg_goal: '3'
 title: Harmful use of alcohol, defined according to the national context as alcohol per capita consumption (aged 15 years and older) within a calendar year in litres of pure alcohol

--- a/meta/3-6-1.md
+++ b/meta/3-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.6.1
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: '03-06-01'
 permalink: /3-6-1/
 sdg_goal: '3'
 title: Death rate due to road traffic injuries

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 3.7.1
 indicator_name: Proportion of women of reproductive age (aged 15-49 years) who have
   their need for family planning satisfied with modern methods
-indicator_sort_order: '0150'
+indicator_sort_order: '03-07-01'
 layout: indicator
 permalink: /3-7-1/
 published: true

--- a/meta/3-7-2.md
+++ b/meta/3-7-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.7.2
 layout: indicator
-indicator_sort_order: '0160'
+indicator_sort_order: '03-07-02'
 permalink: /3-7-2/
 sdg_goal: '3'
 title: Adolescent birth rate (aged 10-14 years; aged 15-19 years) per 1,000 women in that age group

--- a/meta/3-8-1.md
+++ b/meta/3-8-1.md
@@ -7,7 +7,7 @@ indicator_name: Coverage of essential health services (defined as the average co
   of essential services based on tracer interventions that include reproductive, maternal,
   newborn and child health, infectious diseases, non-communicable diseases and service
   capacity and access, among the general and the most disadvantaged population)
-indicator_sort_order: '0170'
+indicator_sort_order: '03-08-01'
 layout: indicator
 permalink: /3-8-1/
 published: true

--- a/meta/3-8-2.md
+++ b/meta/3-8-2.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 3.8.2
 indicator_name: Proportion of population with large household expenditures on health
   as a share of total household expenditure or income
-indicator_sort_order: '0180'
+indicator_sort_order: '03-08-02'
 layout: indicator
 permalink: /3-8-2/
 published: true

--- a/meta/3-9-1.md
+++ b/meta/3-9-1.md
@@ -5,7 +5,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 
 graph_type: line
 indicator: 3.9.1
 indicator_name: Mortality rate attributed to household and ambient air pollution
-indicator_sort_order: '0190'
+indicator_sort_order: '03-09-01'
 layout: indicator
 permalink: /3-9-1/
 published: true

--- a/meta/3-9-2.md
+++ b/meta/3-9-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.9.2
 layout: indicator
-indicator_sort_order: '0200'
+indicator_sort_order: '03-09-02'
 permalink: /3-9-2/
 sdg_goal: '3'
 title: Mortality rate attributed to unsafe water, unsafe sanitation and lack of hygiene

--- a/meta/3-9-3.md
+++ b/meta/3-9-3.md
@@ -6,7 +6,7 @@ permalink: /3-9-3/
 sdg_goal: '3'
 title: Mortality rate attributed to unintentional poisoning
 indicator_name: Mortality rate attributed to unintentional poisoning
-
+indicator_sort_order: '03-09-03'
 target_id: '3.9'
 target: By 2030, substantially reduce the number of deaths and illnesses from hazardous chemicals and air, water and soil pollution and contamination
 

--- a/meta/3-a-1.md
+++ b/meta/3-a-1.md
@@ -19,5 +19,5 @@ title: Age-standardized prevalence of current tobacco use among persons aged 15 
 un_custodian_agency: World Health Organization (WHO), Framework Convention on Tobacco
   Control (FCTC)
 un_designated_tier: 1
-indicator_sort_order: '0220'
+indicator_sort_order: '03-0a-01'
 ---

--- a/meta/3-b-1.md
+++ b/meta/3-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.b.1
 layout: indicator
-indicator_sort_order: '0230'
+indicator_sort_order: '03-0b-01'
 permalink: /3-b-1/
 sdg_goal: '3'
 title: Proportion of the target population covered by all vaccines included in their national programme

--- a/meta/3-b-2.md
+++ b/meta/3-b-2.md
@@ -9,7 +9,7 @@ indicator_definition: Total ODA flows to developing countries quantify the publi
   health.
 indicator_name: Total net official development assistance to medical research and
   basic health sectors
-indicator_sort_order: '0240'
+indicator_sort_order: '03-0b-02'
 layout: indicator
 permalink: /3-b-2/
 published: true

--- a/meta/3-b-3.md
+++ b/meta/3-b-3.md
@@ -4,7 +4,7 @@ graph_type: line
 indicator: 3.b.3
 indicator_name: Proportion of health facilities that have a core set of relevant essential
   medicines available and affordable on a sustainable basis
-indicator_sort_order: '0250'
+indicator_sort_order: '03-0b-03'
 layout: indicator
 permalink: /3-b-3/
 published: true

--- a/meta/3-c-1.md
+++ b/meta/3-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.c.1
 layout: indicator
-indicator_sort_order: '0260'
+indicator_sort_order: '03-0c-01'
 permalink: /3-c-1/
 sdg_goal: '3'
 title: Health worker density and distribution

--- a/meta/3-d-1.md
+++ b/meta/3-d-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 3.d.1
 indicator_name: International Health Regulations (IHR) capacity and health emergency
   preparedness
-indicator_sort_order: '0270'
+indicator_sort_order: '03-0d-01'
 layout: indicator
 permalink: /3-d-1/
 published: true

--- a/meta/4-1-1.md
+++ b/meta/4-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '04-01-01'
 permalink: /4-1-1/
 sdg_goal: '4'
 title: 'Proportion of children and young people: (a) in grades 2/3; (b) at the end of primary; and (c) at the end of lower secondary achieving at least a minimum proficiency level in (i) reading and (ii) mathematics, by sex'

--- a/meta/4-2-1.md
+++ b/meta/4-2-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 4.2.1
 indicator_name: Proportion of children under 5 years of age who are developmentally
   on track in health, learning and psychosocial well-being, by sex
-indicator_sort_order: '0020'
+indicator_sort_order: '04-02-01'
 layout: indicator
 permalink: /4-2-1/
 published: true

--- a/meta/4-2-2.md
+++ b/meta/4-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.2.2
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '04-02-02'
 permalink: /4-2-2/
 sdg_goal: '4'
 title: Participation rate in organized learning (one year before the official primary entry age), by sex

--- a/meta/4-3-1.md
+++ b/meta/4-3-1.md
@@ -2,7 +2,7 @@
 indicator: 4.3.1
 
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '04-03-01'
 permalink: /4-3-1/
 sdg_goal: '4'
 title: Participation rate of youth and adults in formal and non-formal education and training in the previous 12 months, by sex

--- a/meta/4-4-1.md
+++ b/meta/4-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.4.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '04-04-01'
 permalink: /4-4-1/
 sdg_goal: '4'
 title: Proportion of youth and adults with information and communications technology (ICT) skills, by type of skill

--- a/meta/4-5-1.md
+++ b/meta/4-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.5.1
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: '04-05-01'
 permalink: /4-5-1/
 sdg_goal: '4'
 

--- a/meta/4-6-1.md
+++ b/meta/4-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.6.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '04-06-01'
 permalink: /4-6-1/
 sdg_goal: '4'
 title: Proportion of population in a given age group achieving at least a fixed level of proficiency in functional (a) literacy and (b) numeracy skills, by sex

--- a/meta/4-7-1.md
+++ b/meta/4-7-1.md
@@ -7,7 +7,7 @@ indicator_name: "Extent to which (i) global citizenship education and (ii) educa
   \ for sustainable development, including gender equality and human rights, are mainstreamed\
   \ at all levels in: (a) national education policies; (b) curricula; (c) teacher\
   \ education; and (d)\_student assessment"
-indicator_sort_order: '0080'
+indicator_sort_order: '04-07-01'
 layout: indicator
 permalink: /4-7-1/
 published: true

--- a/meta/4-a-1.md
+++ b/meta/4-a-1.md
@@ -8,7 +8,7 @@ indicator_name: "Proportion of schools with access to: (a)\_electricity; (b) the
   \ infrastructure and materials for students with disabilities; (e) basic drinking\
   \ water; (f) single-sex basic sanitation facilities; and (g) basic handwashing facilities\
   \ (as per the WASH indicator definitions)"
-indicator_sort_order: '0090'
+indicator_sort_order: '04-0a-01'
 layout: indicator
 permalink: /4-a-1/
 published: true

--- a/meta/4-b-1.md
+++ b/meta/4-b-1.md
@@ -8,7 +8,7 @@ indicator_definition: Volume of official development assistance flows for schola
   by sector and type of study
 indicator_name: Volume of official development assistance flows for scholarships by
   sector and type of study
-indicator_sort_order: '0100'
+indicator_sort_order: '04-0b-01'
 layout: indicator
 permalink: /4-b-1/
 published: true

--- a/meta/4-c-1.md
+++ b/meta/4-c-1.md
@@ -8,7 +8,7 @@ indicator_name: 'Proportion of teachers in: (a) pre-primary; (b) primary; (c) lo
   secondary; and (d) upper secondary education who have received at least the minimum
   organized teacher training (e.g. pedagogical training) pre-service or in-service
   required for teaching at the relevant level in a given country'
-indicator_sort_order: '0110'
+indicator_sort_order: '04-0c-01'
 layout: indicator
 permalink: /4-c-1/
 published: true

--- a/meta/5-1-1.md
+++ b/meta/5-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '05-01-01'
 permalink: /5-1-1/
 sdg_goal: '5'
 title: "Whether or not legal frameworks are in place to promote, enforce and monitor\ \ equality and non\u2011discrimination on the basis of sex"

--- a/meta/5-2-1.md
+++ b/meta/5-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '05-02-01'
 permalink: /5-2-1/
 sdg_goal: '5'
 title: Proportion of ever-partnered women and girls aged 15 years and older subjected to physical, sexual or psychological violence by a current or former intimate partner in the previous 12 months, by form of violence and by age

--- a/meta/5-2-2.md
+++ b/meta/5-2-2.md
@@ -10,7 +10,7 @@ indicator_definition: Proportion of women and girls aged 15 years and older subj
 indicator_name: Proportion of women and girls aged 15 years and older subjected to
   sexual violence by persons other than an intimate partner in the previous 12 months,
   by age and place of occurrence
-indicator_sort_order: '0030'
+indicator_sort_order: '05-02-02'
 layout: indicator
 permalink: /5-2-2/
 published: true

--- a/meta/5-3-1.md
+++ b/meta/5-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '05-03-01'
 permalink: /5-3-1/
 sdg_goal: '5'
 title: Proportion of women aged 20-24 years who were married or in a union before age 15 and before age 18

--- a/meta/5-3-2.md
+++ b/meta/5-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.3.2
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '05-03-02'
 permalink: /5-3-2/
 sdg_goal: '5'
 title: Proportion of girls and women aged 15-49 years who have undergone female genital mutilation/cutting, by age

--- a/meta/5-4-1.md
+++ b/meta/5-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.4.1
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: '05-04-01'
 permalink: /5-4-1/
 sdg_goal: '5'
 title: Proportion of time spent on unpaid domestic and care work, by sex, age and location

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '05-05-01'
 permalink: /5-5-1/
 sdg_goal: '5'
 title: Proportion of seats held by women in (a) national parliaments and (b) local governments

--- a/meta/5-5-2.md
+++ b/meta/5-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.5.2
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: '05-05-02'
 permalink: /5-5-2/
 sdg_goal: '5'
 title: Proportion of women in managerial positions

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 5.6.1
 indicator_name: Proportion of women aged 15-49 years who make their own informed decisions
   regarding sexual relations, contraceptive use and reproductive health care
-indicator_sort_order: '0090'
+indicator_sort_order: '05-06-01'
 layout: indicator
 permalink: /5-6-1/
 published: true

--- a/meta/5-6-2.md
+++ b/meta/5-6-2.md
@@ -6,7 +6,7 @@ indicator: 5.6.2
 indicator_name: Number of countries with laws and regulations that guarantee full
   and equal access to women and men aged 15 years and older to sexual and reproductive
   health care, information and education
-indicator_sort_order: '0100'
+indicator_sort_order: '05-06-02'
 layout: indicator
 permalink: /5-6-2/
 published: true

--- a/meta/5-a-1.md
+++ b/meta/5-a-1.md
@@ -7,7 +7,7 @@ indicator: 5.a.1
 indicator_name: (a) Proportion of total agricultural population with ownership or
   secure rights over agricultural land, by sex; and (b) share of women among owners
   or rights-bearers of agricultural land, by type of tenure
-indicator_sort_order: '0110'
+indicator_sort_order: '05-0a-01'
 layout: indicator
 permalink: /5-a-1/
 published: true

--- a/meta/5-a-2.md
+++ b/meta/5-a-2.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 5.a.2
 indicator_name: "Proportion of countries where the legal framework (including customary\
   \ law) guarantees women\u2019s equal rights to land ownership and/or control"
-indicator_sort_order: '0120'
+indicator_sort_order: '05-0a-02'
 layout: indicator
 permalink: /5-a-2/
 published: true

--- a/meta/5-b-1.md
+++ b/meta/5-b-1.md
@@ -5,7 +5,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 
 graph_type: line
 indicator: 5.b.1
 indicator_name: Proportion of individuals who own a mobile telephone, by sex
-indicator_sort_order: '0130'
+indicator_sort_order: '05-0b-01'
 layout: indicator
 permalink: /5-b-1/
 published: true

--- a/meta/5-c-1.md
+++ b/meta/5-c-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 5.c.1
 indicator_name: "Proportion of countries with systems to track and make public allocations\
   \ for gender equality and women\u2019s empowerment"
-indicator_sort_order: '0140'
+indicator_sort_order: '05-0c-01'
 layout: indicator
 permalink: /5-c-1/
 published: true

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '06-01-01'
 permalink: /6-1-1/
 sdg_goal: '6'
 title: Proportion of population using safely managed drinking water services

--- a/meta/6-2-1.md
+++ b/meta/6-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '06-02-01'
 permalink: /6-2-1/
 sdg_goal: '6'
 title: Proportion of population using safely managed sanitation services, including a hand-washing facility with soap and water

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.3.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '06-03-01'
 permalink: /6-3-1/
 sdg_goal: '6'
 title: Proportion of wastewater safely treated

--- a/meta/6-3-2.md
+++ b/meta/6-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.3.2
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '06-03-02'
 permalink: /6-3-2/
 sdg_goal: '6'
 title: Proportion of bodies of water with good ambient water quality

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.4.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '06-04-01'
 permalink: /6-4-1/
 sdg_goal: '6'
 title: Change in water-use efficiency over time

--- a/meta/6-4-2.md
+++ b/meta/6-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.4.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: '06-04-02'
 permalink: /6-4-2/
 sdg_goal: '6'
 title: 'Level of water stress: freshwater withdrawal as a proportion of available freshwater resources'

--- a/meta/6-5-1.md
+++ b/meta/6-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '06-05-01'
 permalink: /6-5-1/
 sdg_goal: '6'
 title: Degree of integrated water resources management implementation (0-100)

--- a/meta/6-5-2.md
+++ b/meta/6-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.5.2
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: '06-05-02'
 permalink: /6-5-2/
 sdg_goal: '6'
 title: Proportion of transboundary basin area with an operational arrangement for water cooperation

--- a/meta/6-6-1.md
+++ b/meta/6-6-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 6.6.1
 indicator_name: Change in the extent of water-related ecosystems over time
-indicator_sort_order: '0090'
+indicator_sort_order: '06-06-01'
 layout: indicator
 permalink: /6-6-1/
 published: true

--- a/meta/6-a-1.md
+++ b/meta/6-a-1.md
@@ -13,7 +13,7 @@ indicator_definition: "The amount of water and sanitation-related Official Devel
   \ to developing countries over time."
 indicator_name: Amount of water- and sanitation-related official development assistance
   that is part of a government-coordinated spending plan
-indicator_sort_order: '0100'
+indicator_sort_order: '06-0a-01'
 layout: indicator
 permalink: /6-a-1/
 published: true

--- a/meta/6-b-1.md
+++ b/meta/6-b-1.md
@@ -6,7 +6,7 @@ indicator: 6.b.1
 indicator_name: Proportion of local administrative units with established and operational
   policies and procedures for participation of local communities in water and sanitation
   management
-indicator_sort_order: '0110'
+indicator_sort_order: '06-0b-01'
 layout: indicator
 permalink: /6-b-1/
 published: true

--- a/meta/7-1-1.md
+++ b/meta/7-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '07-01-01'
 permalink: /7-1-1/
 sdg_goal: '7'
 title: Proportion of population with access to electricity

--- a/meta/7-1-2.md
+++ b/meta/7-1-2.md
@@ -13,7 +13,7 @@ indicator_definition: "Proportion of population with primary reliance on clean f
   \ air quality: household fuel combustion."
 indicator_name: Proportion of population with primary reliance on clean fuels and
   technology
-indicator_sort_order: '0020'
+indicator_sort_order: '07-01-02'
 layout: indicator
 permalink: /7-1-2/
 published: true

--- a/meta/7-2-1.md
+++ b/meta/7-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '07-02-01'
 permalink: /7-2-1/
 sdg_goal: '7'
 title: Renewable energy share in the total final energy consumption

--- a/meta/7-3-1.md
+++ b/meta/7-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '07-03-01'
 permalink: /7-3-1/
 sdg_goal: '7'
 title: Energy intensity measured in terms of primary energy and GDP

--- a/meta/7-a-1.md
+++ b/meta/7-a-1.md
@@ -9,7 +9,7 @@ indicator_definition: Mobilized amount of United States dollars per year startin
 indicator_name: International financial flows to developing countries in support of
   clean energy research and development and renewable energy production, including
   in hybrid systems
-indicator_sort_order: '0050'
+indicator_sort_order: '07-0a-01'
 layout: indicator
 permalink: /7-a-1/
 published: true

--- a/meta/7-b-1.md
+++ b/meta/7-b-1.md
@@ -7,7 +7,7 @@ indicator: 7.b.1
 indicator_name: Investments in energy efficiency as a proportion of GDP and the amount
   of foreign direct investment in financial transfer for infrastructure and technology
   to sustainable development services
-indicator_sort_order: '0060'
+indicator_sort_order: '07-0b-01'
 layout: indicator
 permalink: /7-b-1/
 published: true

--- a/meta/8-1-1.md
+++ b/meta/8-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: '08-01-01'
 permalink: /8-1-1/
 sdg_goal: '8'
 title: Annual growth rate of real GDP per capita

--- a/meta/8-10-1.md
+++ b/meta/8-10-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.10.1
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: '08-10-01'
 permalink: /8-10-1/
 sdg_goal: '8'
 title: (a) Number of commercial bank branches per 100,000 adults and (b) number of automated teller machines (ATMs) per 100,000 adults

--- a/meta/8-10-2.md
+++ b/meta/8-10-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.10.2
 layout: indicator
-indicator_sort_order: '0150'
+indicator_sort_order: '08-10-02'
 permalink: /8-10-2/
 sdg_goal: '8'
 title: Proportion of adults (15 years and older) with an account at a bank or other financial institution or with a mobile-money-service provider

--- a/meta/8-2-1.md
+++ b/meta/8-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '08-02-01'
 permalink: /8-2-1/
 sdg_goal: '8'
 title: Annual growth rate of real GDP per employed person

--- a/meta/8-3-1.md
+++ b/meta/8-3-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 8.3.1
 indicator_name: Proportion of informal employment in non-agriculture employment, by
   sex
-indicator_sort_order: '0030'
+indicator_sort_order: '08-03-01'
 layout: indicator
 permalink: /8-3-1/
 published: true

--- a/meta/8-4-1.md
+++ b/meta/8-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.4.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '08-04-01'
 permalink: /8-4-1/
 sdg_goal: '8'
 title: Material footprint, material footprint per capita, and material footprint per GDP

--- a/meta/8-4-2.md
+++ b/meta/8-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.4.2
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '08-04-02'
 permalink: /8-4-2/
 sdg_goal: '8'
 title: Domestic material consumption, domestic material consumption per capita, and domestic material consumption per GDP

--- a/meta/8-5-1.md
+++ b/meta/8-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.5.1
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: '08-05-01'
 permalink: /8-5-1/
 sdg_goal: '8'
 title: Average hourly earnings of female and male employees, by occupation, age and persons with disabilities

--- a/meta/8-5-2.md
+++ b/meta/8-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.5.2
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '08-05-02'
 permalink: /8-5-2/
 sdg_goal: '8'
 title: Unemployment rate, by sex, age and persons with disabilities

--- a/meta/8-6-1.md
+++ b/meta/8-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.6.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: '08-06-01'
 permalink: /8-6-1/
 sdg_goal: '8'
 title: Proportion of youth (aged 15-24 years) not in education, employment or training

--- a/meta/8-7-1.md
+++ b/meta/8-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.7.1
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '08-07-01'
 permalink: /8-7-1/
 sdg_goal: '8'
 title: "Proportion and number of children aged 5\u201117\_years engaged in child labour, by sex and age"

--- a/meta/8-8-1.md
+++ b/meta/8-8-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.8.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: '08-08-01'
 permalink: /8-8-1/
 sdg_goal: '8'
 title: Frequency rates of fatal and non-fatal occupational injuries, by sex and migrant status

--- a/meta/8-8-2.md
+++ b/meta/8-8-2.md
@@ -6,7 +6,7 @@ indicator: 8.8.2
 indicator_name: Level of national compliance of labour rights (freedom of association
   and collective bargaining) based on International Labour Organization (ILO) textual
   sources and national legislation, by sex and migrant status
-indicator_sort_order: '0110'
+indicator_sort_order: '08-08-02'
 layout: indicator
 permalink: /8-8-2/
 published: true

--- a/meta/8-9-1.md
+++ b/meta/8-9-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.9.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: '08-09-01'
 permalink: /8-9-1/
 sdg_goal: '8'
 title: Tourism direct GDP as a proportion of total GDP and in growth rate

--- a/meta/8-9-2.md
+++ b/meta/8-9-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.9.2
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: '08-09-02'
 permalink: /8-9-2/
 sdg_goal: '8'
 title: Proportion of jobs in sustainable tourism industries out of total tourism jobs

--- a/meta/8-a-1.md
+++ b/meta/8-a-1.md
@@ -5,7 +5,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 
 graph_type: line
 indicator: 8.a.1
 indicator_name: Aid for Trade commitments and disbursements
-indicator_sort_order: '0160'
+indicator_sort_order: '08-0a-01'
 layout: indicator
 permalink: /8-a-1/
 published: true

--- a/meta/8-b-1.md
+++ b/meta/8-b-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 8.b.1
 indicator_name: Existence of a developed and operationalized national strategy for
   youth employment, as a distinct strategy or as part of a national employment strategy
-indicator_sort_order: '0170'
+indicator_sort_order: '08-0b-01'
 layout: indicator
 permalink: /8-b-1/
 published: true

--- a/meta/9-1-1.md
+++ b/meta/9-1-1.md
@@ -5,7 +5,7 @@ graph_type: line
 indicator: 9.1.1
 indicator_name: "Proportion of the rural population who live within 2\_km of an all-season\
   \ road"
-indicator_sort_order: '0010'
+indicator_sort_order: '09-01-01'
 layout: indicator
 permalink: /9-1-1/
 published: true

--- a/meta/9-1-2.md
+++ b/meta/9-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: '09-01-02'
 permalink: /9-1-2/
 sdg_goal: '9'
 title: Passenger and freight volumes, by mode of transport

--- a/meta/9-2-1.md
+++ b/meta/9-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: '09-02-01'
 permalink: /9-2-1/
 sdg_goal: '9'
 title: Manufacturing value added as a proportion of GDP and per capita

--- a/meta/9-2-2.md
+++ b/meta/9-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.2.2
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: '09-02-02'
 permalink: /9-2-2/
 sdg_goal: '9'
 title: Manufacturing employment as a proportion of total employment

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.3.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: '09-03-01'
 permalink: /9-3-1/
 sdg_goal: '9'
 title: Proportion of small-scale industries in total industry value added

--- a/meta/9-3-2.md
+++ b/meta/9-3-2.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 9.3.2
 indicator_name: Proportion of small-scale industries with a loan or line of credit
-indicator_sort_order: '0060'
+indicator_sort_order: '09-03-02'
 layout: indicator
 permalink: /9-3-2/
 published: true

--- a/meta/9-4-1.md
+++ b/meta/9-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.4.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: '09-04-01'
 permalink: /9-4-1/
 sdg_goal: '9'
 title: CO2emission per unit of value added

--- a/meta/9-5-1.md
+++ b/meta/9-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.5.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: '09-05-01'
 permalink: /9-5-1/
 sdg_goal: '9'
 title: Research and development expenditure as a proportion of GDP

--- a/meta/9-5-2.md
+++ b/meta/9-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.5.2
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: '09-05-02'
 permalink: /9-5-2/
 sdg_goal: '9'
 title: Researchers (in full-time equivalent) per million inhabitants

--- a/meta/9-a-1.md
+++ b/meta/9-a-1.md
@@ -8,7 +8,7 @@ indicator_definition: Total resource flows for infrastructure, comprising Offici
   Development Assistance (ODA), other official flows (OOF) and private flows
 indicator_name: Total official international support (official development assistance
   plus other official flows) to infrastructure
-indicator_sort_order: '0100'
+indicator_sort_order: '09-0a-01'
 layout: indicator
 permalink: /9-a-1/
 published: true

--- a/meta/9-b-1.md
+++ b/meta/9-b-1.md
@@ -6,7 +6,7 @@ graph_type: line
 indicator: 9.b.1
 indicator_name: Proportion of medium and high-tech industry value added in total value
   added
-indicator_sort_order: '0110'
+indicator_sort_order: '09-0b-01'
 layout: indicator
 permalink: /9-b-1/
 published: true

--- a/meta/9-c-1.md
+++ b/meta/9-c-1.md
@@ -4,7 +4,7 @@ goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 
 graph_type: line
 indicator: 9.c.1
 indicator_name: Proportion of population covered by a mobile network, by technology
-indicator_sort_order: '0120'
+indicator_sort_order: '09-0c-01'
 layout: indicator
 permalink: /9-c-1/
 published: true


### PR DESCRIPTION
This is the first in a two-step process to fix the order of the indicators on goal pages. This changes the values of "indicator_sort_order" to a non-numeric value, which avoids errors in Jekyll/Liquid when trying to sort by that.