### PR TITLE
Prep for Open SDG 0.5.0

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -119,12 +119,12 @@ prose:
             element: select
             label: "Reporting status"
             options:
-              - name: 'notstarted'
-                value: 'notstarted'
-              - name: 'inprogress'
-                value: 'inprogress'
               - name: 'complete'
                 value: 'complete'
+              - name: 'inprogress'
+                value: 'inprogress'
+              - name: 'notstarted'
+                value: 'notstarted'
             scope: data
       - name: data_non_statistical
         field:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,4 +3,4 @@ pandas
 gitpython
 ruamel.yaml>=0.15
 git+git://github.com/dougmet/yamlmd
-git+git://github.com/open-sdg/sdg-build@0.2.1
+git+git://github.com/open-sdg/sdg-build@0.3.1


### PR DESCRIPTION
This updates the version of SDG Build and re-arranges the options for reporting_status, in preparation for Open SDG 0.5.0, which was just released.