### PR TITLE
Possible way to achieve multiple source links

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -229,6 +229,32 @@ prose:
             label: "Link to data source text"
             value: "Link to source"
             scope: source_1
+      - name: "source_url_1b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_1
+      - name: "source_url_text_1b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            value: "Link to source"
+            scope: source_1
+      - name: "source_url_1c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_1
+      - name: "source_url_text_1c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source text
+            value: "Link to source"
+            scope: source_1
       ## Source 2
       - name: source_active_2
         field:
@@ -256,6 +282,32 @@ prose:
             element: text
             label: "Link to data source text"
             value: "Link to Source"
+            scope: source_2
+      - name: "source_url_2b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_2
+      - name: "source_url_text_2b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            value: "Link to source"
+            scope: source_2
+      - name: "source_url_2c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_2
+      - name: "source_url_text_2c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source text
+            value: "Link to source"
             scope: source_2
       ## Source 3
       - name: source_active_3
@@ -285,6 +337,32 @@ prose:
             element: text
             label: "Link to data source text"
             scope: source_3
+      - name: "source_url_3b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_3
+      - name: "source_url_text_3b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            value: "Link to source"
+            scope: source_3
+      - name: "source_url_3c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_3
+      - name: "source_url_text_3c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source text
+            value: "Link to source"
+            scope: source_3
       ## Source 4
       - name: source_active_4
         field:
@@ -311,6 +389,32 @@ prose:
         field:
             element: text
             label: "Link to data source text"
+            value: "Link to source"
+            scope: source_4
+      - name: "source_url_4b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_4
+      - name: "source_url_text_4b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            value: "Link to source"
+            scope: source_4
+      - name: "source_url_4c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_4
+      - name: "source_url_text_4c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source text
             value: "Link to source"
             scope: source_4
 ## Source 5
@@ -341,6 +445,32 @@ prose:
             label: "Link to data source text"
             value: "Link to source"
             scope: source_5
+      - name: "source_url_5b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_5
+      - name: "source_url_text_5b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            value: "Link to source"
+            scope: source_5
+      - name: "source_url_5c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_5
+      - name: "source_url_text_5c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source text
+            value: "Link to source"
+            scope: source_5
 ## Source 6
       - name: source_active_6
         field:
@@ -367,5 +497,31 @@ prose:
         field:
             element: text
             label: "Link to data source text"
+            value: "Link to source"
+            scope: source_6
+      - name: "source_url_6b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_6
+      - name: "source_url_text_6b"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            value: "Link to source"
+            scope: source_6
+      - name: "source_url_6c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source
+            scope: source_6
+      - name: "source_url_text_6c"
+        field:
+            element: text
+            label: ""
+            help: Additional link to data source text
             value: "Link to source"
             scope: source_6

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -33,6 +33,10 @@ source_organisation_1: Statistisches Bundesamt (Destatis)
 source_organisation_logo_1: <a href="https://www.destatis.de"><img src="https://g205sdgs.github.io/sdg-indicators/public/logos/destatis.png" alt="Logo Destatis" /></a>
 source_url_1: https://www.destatis.de/DE/Themen/Gesellschaft-Umwelt/Einkommen-Konsum-Lebensbedingungen/Lebensbedingungen-Armutsgefaehrdung/_inhalt.html#sprg233586
 source_url_text_1: "EU-SILC, Income and Living Conditions in Germany and the European Union - Fachserie 15, Reihe 3"
+source_url_1b: https://example.com
+source_url_text_1b: "A second link"
+source_url_1c: https://example.com
+source_url_text_1c: "A third link"
 
 source_active_2: false
 source_organisation_logo_2:


### PR DESCRIPTION
This is a possible way to achieve multiple source links, without requiring any custom code. It hardcodes 2 additional link fields per source, which can be used for second and third links. It intentionally sets their "label" to a blank string, so that they will appear visually to be a continuation of the first link.